### PR TITLE
Pin to django-redis==4.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     ],
     description=description.strip(),
     install_requires=[
-        "django-redis>=4.5.0",
+        "django-redis==4.5.0",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
There is no backwards compatibility in newer releases of
django-redis which makes this module to throw exceptions
during initialization.